### PR TITLE
refactor(vm): 重构虚拟机栈和帧结构

### DIFF
--- a/src/byte_code_vm/vm/frame.rs
+++ b/src/byte_code_vm/vm/frame.rs
@@ -5,6 +5,7 @@ use crate::{byte_code_vm::code::code::{instruction_to_str_with_indent, Instructi
 #[derive(Clone, Debug)]
 pub struct Frame {
     pub func: Rc<RefCell<CompiledFunction>>,
+    pub stack: Rc<RefCell<Vec<Object>>>,
     pub locals: Rc<RefCell<Vec<Object>>>,
     pub ip: isize,
     pub base_pointer: usize
@@ -16,6 +17,7 @@ impl Frame {
             func,
             ip: -1,
             base_pointer,
+            stack: rc_ref_cell!(vec![]),
             locals: rc_ref_cell!(vec![])
         }
     }


### PR DESCRIPTION
- 在 Frame 结构中添加 stack 字段，用于存储帧内的栈
- 将 Vm 结构中的 stack 改为 Rc<RefCell<Vec<Object>>> 类型
- 更新相关函数以适应新的栈和帧结构
- 优化部分代码格式和命名