### PR TITLE
使用blanket implementation取代impl_node宏

### DIFF
--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -4,11 +4,16 @@ use std::fmt::Debug;
 
 use crate::constants::NEW_LINE;
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 pub trait TypeNameGetter {
     fn type_name(&self) -> String;
+}
+
+impl<T: Node> TypeNameGetter for T {
+    fn type_name(&self) -> String {
+        self.to_string()
+    }
 }
 
 pub trait Node: DynClone + Sync + Send + Any + Debug + TypeNameGetter {
@@ -77,8 +82,6 @@ impl Node for Program {
     }
 }
 
-impl_node!(Program);
-
 impl Clone for ExpressionStatement {
     fn clone(&self) -> Self {
         Self {
@@ -118,5 +121,3 @@ pub fn create_expression_statement(expression: impl Expression + 'static) -> Exp
         expression: Some(Box::new(expression) as Box<dyn Expression>),
     }
 }
-
-impl_node!(ExpressionStatement);

--- a/src/ast/expressions/array_literal.rs
+++ b/src/ast/expressions/array_literal.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for ArrayLiteral {
@@ -33,8 +32,6 @@ impl Node for ArrayLiteral {
         format!("[{}]", item_strings.join(", "))
     }
 }
-
-impl_node!(ArrayLiteral);
 
 impl Expression for ArrayLiteral {}
 

--- a/src/ast/expressions/assignment_expression.rs
+++ b/src/ast/expressions/assignment_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for AssignmentExpression {
@@ -29,8 +28,6 @@ impl Node for AssignmentExpression {
         format!("{} = {}", self.left.to_string(), self.value.to_string())
     }
 }
-
-impl_node!(AssignmentExpression);
 
 impl Expression for AssignmentExpression {}
 

--- a/src/ast/expressions/boolean_literal.rs
+++ b/src/ast/expressions/boolean_literal.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for BooleanLiteral {
@@ -29,8 +28,6 @@ impl Node for BooleanLiteral {
 }
 
 impl Expression for BooleanLiteral {}
-
-impl_node!(BooleanLiteral);
 
 pub fn create_boolean_literal(token: Token, value: bool) -> BooleanLiteral {
     BooleanLiteral { token, value }

--- a/src/ast/expressions/call_expression.rs
+++ b/src/ast/expressions/call_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for CallExpression {
@@ -35,8 +34,6 @@ impl Node for CallExpression {
         format!("{}({})", self.func.to_string(), args_strings.join(", "))
     }
 }
-
-impl_node!(CallExpression);
 
 impl Expression for CallExpression {}
 

--- a/src/ast/expressions/class_member_expression.rs
+++ b/src/ast/expressions/class_member_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for ClassMemberExpression {
@@ -31,8 +30,6 @@ impl Node for ClassMemberExpression {
 }
 
 impl Expression for ClassMemberExpression {}
-
-impl_node!(ClassMemberExpression);
 
 pub fn create_class_member_expression(
     token: Token,

--- a/src/ast/expressions/double_literal.rs
+++ b/src/ast/expressions/double_literal.rs
@@ -2,7 +2,6 @@ use bigdecimal::BigDecimal;
 
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for DoubleLiteral {
@@ -31,8 +30,6 @@ impl Node for DoubleLiteral {
 }
 
 impl Expression for DoubleLiteral {}
-
-impl_node!(DoubleLiteral);
 
 pub fn create_double_literal(token: Token, value: BigDecimal) -> DoubleLiteral {
     DoubleLiteral { token, value }

--- a/src/ast/expressions/function_expression.rs
+++ b/src/ast/expressions/function_expression.rs
@@ -2,7 +2,6 @@ use crate::ast::ast::{Expression, Node};
 use crate::ast::statements::block_statement::BlockStatement;
 use crate::ast::utils::expressions_to_string;
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for FunctionExpression {
@@ -38,8 +37,6 @@ impl Node for FunctionExpression {
         )
     }
 }
-
-impl_node!(FunctionExpression);
 
 impl Expression for FunctionExpression {}
 

--- a/src/ast/expressions/identifier.rs
+++ b/src/ast/expressions/identifier.rs
@@ -1,8 +1,6 @@
 use crate::ast::ast::{Expression, Node};
 use crate::token::token::Token;
 
-use crate::impl_node;
-
 impl Clone for Identifier {
     fn clone(&self) -> Self {
         Self {
@@ -29,8 +27,6 @@ impl Node for Identifier {
 }
 
 impl Expression for Identifier {}
-
-impl_node!(Identifier);
 
 pub fn create_identifier(token: Token, value: String) -> Identifier {
     Identifier { token, value }

--- a/src/ast/expressions/if_expression.rs
+++ b/src/ast/expressions/if_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node, Statement};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for IfExpression {
@@ -128,6 +127,3 @@ pub fn create_else_if_expression(
         consequence,
     }
 }
-
-impl_node!(IfExpression);
-impl_node!(ElseIfExpression);

--- a/src/ast/expressions/index_expression.rs
+++ b/src/ast/expressions/index_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for IndexExpression {
@@ -29,8 +28,6 @@ impl Node for IndexExpression {
         format!("{}[{}]", self.expr.to_string(), self.index.to_string())
     }
 }
-
-impl_node!(IndexExpression);
 
 impl Expression for IndexExpression {}
 

--- a/src/ast/expressions/infix_expression.rs
+++ b/src/ast/expressions/infix_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for InfixExpression {
@@ -36,8 +35,6 @@ impl Node for InfixExpression {
         )
     }
 }
-
-impl_node!(InfixExpression);
 
 impl Expression for InfixExpression {}
 

--- a/src/ast/expressions/integer_literal.rs
+++ b/src/ast/expressions/integer_literal.rs
@@ -1,7 +1,6 @@
 use bigdecimal::BigDecimal;
 
 use crate::ast::ast::{Expression, Node};
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for IntegerLiteral {
@@ -30,8 +29,6 @@ impl Node for IntegerLiteral {
 }
 
 impl Expression for IntegerLiteral {}
-
-impl_node!(IntegerLiteral);
 
 pub fn create_integer_literal(token: Token, value: BigDecimal) -> IntegerLiteral {
     IntegerLiteral { token, value }

--- a/src/ast/expressions/object_member_expression.rs
+++ b/src/ast/expressions/object_member_expression.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for ObjectMemberExpression {
@@ -31,8 +30,6 @@ impl Node for ObjectMemberExpression {
 }
 
 impl Expression for ObjectMemberExpression {}
-
-impl_node!(ObjectMemberExpression);
 
 pub fn create_object_member_expression(
     token: Token,

--- a/src/ast/expressions/prefix_expression.rs
+++ b/src/ast/expressions/prefix_expression.rs
@@ -1,8 +1,6 @@
 use crate::ast::ast::{Expression, Node};
 use crate::token::token::Token;
 
-use crate::impl_node;
-
 impl Clone for PrefixExpression {
     fn clone(&self) -> Self {
         Self {
@@ -31,8 +29,6 @@ impl Node for PrefixExpression {
 }
 
 impl Expression for PrefixExpression {}
-
-impl_node!(PrefixExpression);
 
 pub fn create_prefix_expression(
     token: Token,

--- a/src/ast/expressions/return_expression.rs
+++ b/src/ast/expressions/return_expression.rs
@@ -1,8 +1,6 @@
 use crate::ast::ast::{Expression, Node};
 use crate::token::token::Token;
 
-use crate::impl_node;
-
 impl Clone for ReturnExpression {
     fn clone(&self) -> Self {
         Self {
@@ -29,8 +27,6 @@ impl Node for ReturnExpression {
 }
 
 impl Expression for ReturnExpression {}
-
-impl_node!(ReturnExpression);
 
 pub fn create_return_expression(token: Token, value: Box<dyn Expression>) -> ReturnExpression {
     ReturnExpression { token, value }

--- a/src/ast/expressions/string_literal.rs
+++ b/src/ast/expressions/string_literal.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for StringLiteral {
@@ -29,8 +28,6 @@ impl Node for StringLiteral {
 }
 
 impl Expression for StringLiteral {}
-
-impl_node!(StringLiteral);
 
 pub fn create_string_literal(token: Token, value: String) -> StringLiteral {
     StringLiteral { token, value }

--- a/src/ast/expressions/test_print_expression.rs
+++ b/src/ast/expressions/test_print_expression.rs
@@ -1,8 +1,6 @@
 use crate::ast::ast::{Expression, Node};
 use crate::token::token::Token;
 
-use crate::impl_node;
-
 impl Clone for TestPrintExpression {
     fn clone(&self) -> Self {
         Self {
@@ -29,8 +27,6 @@ impl Node for TestPrintExpression {
 }
 
 impl Expression for TestPrintExpression {}
-
-impl_node!(TestPrintExpression);
 
 pub fn create_test_print_expression(
     token: Token,

--- a/src/ast/expressions/tuple_expression.rs
+++ b/src/ast/expressions/tuple_expression.rs
@@ -1,5 +1,4 @@
 use crate::ast::ast::{Expression, Node};
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for TupleExpression {
@@ -34,8 +33,6 @@ impl Node for TupleExpression {
 }
 
 impl Expression for TupleExpression {}
-
-impl_node!(TupleExpression);
 
 pub fn create_tuple_expression(
     token: Token,

--- a/src/ast/statements/block_statement.rs
+++ b/src/ast/statements/block_statement.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use crate::ast::ast::{Node, Statement};
 use crate::constants::NEW_LINE;
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for BlockStatement {
@@ -40,8 +39,6 @@ impl Node for BlockStatement {
         s
     }
 }
-
-impl_node!(BlockStatement);
 
 impl Statement for BlockStatement {}
 

--- a/src/ast/statements/class_statement.rs
+++ b/src/ast/statements/class_statement.rs
@@ -1,7 +1,6 @@
 use crate::ast::ast::{Node, Statement};
 use crate::ast::expressions::identifier::Identifier;
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 use super::block_statement::BlockStatement;
@@ -47,8 +46,6 @@ impl Node for ClassStatement {
         }
     }
 }
-
-impl_node!(ClassStatement);
 
 impl Statement for ClassStatement {}
 

--- a/src/ast/statements/let_statement.rs
+++ b/src/ast/statements/let_statement.rs
@@ -1,7 +1,6 @@
 use crate::ast::ast::{Expression, Node, Statement};
 use crate::ast::expressions::identifier::Identifier;
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 impl Clone for LetStatement {
@@ -30,8 +29,6 @@ impl Node for LetStatement {
         format!("let {} = {}", self.name.to_string(), self.value.to_string())
     }
 }
-
-impl_node!(LetStatement);
 
 impl Statement for LetStatement {}
 

--- a/src/ast/statements/while_statement.rs
+++ b/src/ast/statements/while_statement.rs
@@ -1,6 +1,5 @@
 use crate::ast::ast::{Expression, Node, Statement};
 
-use crate::impl_node;
 use crate::token::token::Token;
 
 use super::block_statement::BlockStatement;
@@ -37,8 +36,6 @@ impl Node for WhileStatement {
 }
 
 impl Statement for WhileStatement {}
-
-impl_node!(WhileStatement);
 
 pub fn create_while_statement(
     token: Token,

--- a/src/ast/utils.rs
+++ b/src/ast/utils.rs
@@ -19,14 +19,3 @@ pub fn expressions_to_string(expressions: &Vec<Box<dyn Expression>>, separator: 
 
     strings.join(separator)
 }
-
-#[macro_export]
-macro_rules! impl_node {
-    ($struct_name:ident) => {
-        impl crate::ast::ast::TypeNameGetter for $struct_name {
-            fn type_name(&self) -> String {
-                stringify!($struct_name).to_string()
-            }
-        }
-    };
-}

--- a/src/byte_code_vm/constants.rs
+++ b/src/byte_code_vm/constants.rs
@@ -4,6 +4,6 @@ use crate::object::{ant_boolean::AntBoolean, ant_uninit::AntUninit};
 
 pub static TRUE: Lazy<AntBoolean> = Lazy::new(|| AntBoolean::from(true));
 pub static FALSE: Lazy<AntBoolean> = Lazy::new(|| AntBoolean::from(false));
-pub static UNINIT_OBJ: Lazy<AntUninit> = Lazy::new(|| AntUninit::create());
+pub static UNINIT_OBJ: Lazy<AntUninit> = Lazy::new(AntUninit::create);
 
 pub const FAKE_OFFSET_JUMP: u16 = 91 * 2 + 78 * 4 + 13 * 2;


### PR DESCRIPTION
impl_node宏的功能可以直接改为为所有实现Node的物件实现TypeNameGetter